### PR TITLE
ci: deprecated actions/upload-artifact@v3

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "public"
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
The PR is fixing the [failing](https://github.com/lottie/lottie.github.io/actions/runs/13525618164/job/37795294804) CI: 

```
Error: This request has been automatically failed because it uses a deprecated version of 
`actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```