### PR TITLE
fix(content) mime-type news description cannot represent value

### DIFF
--- a/content/news/announcing-lac-iana-mime-type/index.md
+++ b/content/news/announcing-lac-iana-mime-type/index.md
@@ -1,8 +1,7 @@
 ---
 title: Lottie Animation Community Achieves Formal Recognition from IANA and IESG
 date: "2025-02-24T12:13:57.284Z"
-description: 
-- 'Announcing formal assignment of ".lot" file extension and the "video/lottie+json" MIME type with the Internet Assigned Numbers Authority (IANA).'
+description: "Announcing formal assignment of .lot file extension and the video/lottie+json MIME type with the Internet Assigned Numbers Authority (IANA)."
 featuredImage: lac-announce-mime-type-and-lot.png
 ---
 


### PR DESCRIPTION
the ci build is [failing](https://github.com/lottie/lottie.github.io/actions/runs/13527147171/job/37800487152) for the description field, locally it was ok though