### PR TITLE
ci: bump deploy-pages to v4 to fix deploy pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,4 +35,4 @@ jobs:
           path: "public"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
the deploy pages is [failing](https://github.com/lottie/lottie.github.io/actions/runs/13527699165) after latest upload-pages-artifact updates